### PR TITLE
Adds Power and Energy entities to the same device as the thermostat they belong to

### DIFF
--- a/custom_components/xcomfort_bridge/sensor.py
+++ b/custom_components/xcomfort_bridge/sensor.py
@@ -84,8 +84,9 @@ class XComfortPowerSensor(SensorEntity):
         )
         self.hub = hub
         self._room = room
-        self._attr_name = self._room.name
+        self._attr_name = f"{self._room.name} Power"
         self._attr_unique_id = f"energy_{self._room.room_id}"
+        self._unique_id = f"energy_{self._room.room_id}"
         self._state = None
         self._room.state.subscribe(lambda state: self._state_change(state))
 
@@ -131,8 +132,9 @@ class XComfortEnergySensor(RestoreSensor):
         )
         self.hub = hub
         self._room = room
-        self._attr_name = self._room.name
+        self._attr_name = f"{self._room.name} Energy"
         self._attr_unique_id = f"energy_kwh_{self._room.room_id}"
+        self._unique_id = f"energy_kwh_{self._room.room_id}"
         self._state = None
         self._room.state.subscribe(lambda state: self._state_change(state))
         self._updateTime = time.monotonic()


### PR DESCRIPTION
Address issue #45 

I was setting this custom component on my HASS, and I agree with the poster of this issue that it would make sense to group these sensors to the same device as the thermostat they belong. So i added a fix for this, and hope that this make sense for others