### PR TITLE
Upgrading dev containter environment for development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/devcontainers/python:3.13
+
+USER vscode
+WORKDIR /home/vscode
+
+RUN python3 -m pip --no-cache-dir install \
+    homeassistant==2025.7.1 \
+    pip>=21.3.1 \
+    xcomfort==0.1.2

--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -1,8 +1,0 @@
-default_config:
-
-logger:
-  default: info
-  logs:
-    custom_components.{{cookiecutter.domain_name}}: debug
-# If you need to debug uncommment the line below (doc: https://www.home-assistant.io/integrations/debugpy/)
-# debugpy:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 {
   "name": "HA Xcomfort bridge integration development",
-  "image": "mcr.microsoft.com/devcontainers/python:3.13",
-  "postCreateCommand": "python3 -m pip install --requirement requirements.txt",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
   "forwardPorts": [
     8123
   ],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,9 @@
       ],
       "settings": {
         "files.eol": "\n",
+        "files.associations": {
+          "*.yaml": "home-assistant"
+        },
         "editor.tabSize": 4,
         "terminal.integrated.defaultProfile.linux": "bash",
         "python.pythonPath": "/usr/bin/python3",
@@ -32,7 +35,11 @@
         "editor.formatOnPaste": false,
         "editor.formatOnSave": true,
         "editor.formatOnType": true,
-        "files.trimTrailingWhitespace": true
+        "files.trimTrailingWhitespace": true,
+        "ruff.enable": true,
+        "ruff.fixAll": true,
+        "ruff.lint.enable": true,
+        "ruff.lineLength": 120
       }
     }
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,30 +1,48 @@
-  // See https://aka.ms/vscode-remote/devcontainer.json for format details.
-  {
-    "name": "HA Xcomfort bridge integration development",
-    "image": "ghcr.io/ludeeus/devcontainer/integration:23.2.0",
-    "context": "..",
-    "appPort": [
-      "9123:8123"
-    ],
-    "postCreateCommand": "container install",
-    "extensions": [
-      "ms-python.python",
-      "github.vscode-pull-request-github",
-      "ryanluker.vscode-coverage-gutters",
-      "ms-python.vscode-pylance"
-    ],
-    "settings": {
-      "files.eol": "\n",
-      "editor.tabSize": 4,
-      "terminal.integrated.defaultProfile.linux": "bash",
-      "python.pythonPath": "/usr/bin/python3",
-      "python.analysis.autoSearchPaths": false,
-      "python.linting.pylintEnabled": true,
-      "python.linting.enabled": true,
-      "python.formatting.provider": "black",
-      "editor.formatOnPaste": false,
-      "editor.formatOnSave": true,
-      "editor.formatOnType": true,
-      "files.trimTrailingWhitespace": true
+{
+  "name": "HA Xcomfort bridge integration development",
+  "image": "mcr.microsoft.com/devcontainers/python:3.13",
+  "postCreateCommand": "python3 -m pip install --requirement requirements.txt",
+  "forwardPorts": [
+    8123
+  ],
+  "portsAttributes": {
+    "8123": {
+      "label": "Home Assistant",
+      "onAutoForward": "notify"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "github.vscode-pull-request-github",
+        "ryanluker.vscode-coverage-gutters",
+        "ms-python.vscode-pylance"
+      ],
+      "settings": {
+        "files.eol": "\n",
+        "editor.tabSize": 4,
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "python.pythonPath": "/usr/bin/python3",
+        "python.analysis.autoSearchPaths": false,
+        "python.linting.pylintEnabled": true,
+        "python.linting.enabled": true,
+        "python.formatting.provider": "black",
+        "editor.formatOnPaste": false,
+        "editor.formatOnSave": true,
+        "editor.formatOnType": true,
+        "files.trimTrailingWhitespace": true
+      }
+    }
+  },
+  "remoteUser": "vscode",
+  "features": {
+    "ghcr.io/devcontainers-extra/features/apt-packages:1": {
+      "packages": [
+        "ffmpeg",
+        "libturbojpeg0",
+        "libpcap-dev"
+      ]
     }
   }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,11 +27,11 @@
         },
         "editor.tabSize": 4,
         "terminal.integrated.defaultProfile.linux": "bash",
-        "python.pythonPath": "/usr/bin/python3",
+        "[python]": {
+          "editor.formatOnType": true,
+          "editor.defaultFormatter": "charliermarsh.ruff"
+        },
         "python.analysis.autoSearchPaths": false,
-        "python.linting.pylintEnabled": true,
-        "python.linting.enabled": true,
-        "python.formatting.provider": "black",
         "editor.formatOnPaste": false,
         "editor.formatOnSave": true,
         "editor.formatOnType": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,8 @@
         "ms-python.python",
         "github.vscode-pull-request-github",
         "ryanluker.vscode-coverage-gutters",
-        "ms-python.vscode-pylance"
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff"
       ],
       "settings": {
         "files.eol": "\n",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,0 @@
-{
-    "recommendations": [
-        "ms-vscode-remote.remote-containers"
-    ]
-}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,15 +4,18 @@
   "configurations": [
     {
       "name": "Python: Launch HomeAssistant",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
-      "program": "/usr/local/python/bin/hass",
+      "preLaunchTask": "Make config folder",
+      "program": "~/.local/bin/hass",
+      "env": {
+        "PYTHONPATH": "${env:PYTHONPATH}:${workspaceFolder}/custom_components"
+      },
       "args": [
-        "-c",
-        "${workspaceFolder}",
+        "--config",
+        "${workspaceFolder}/config",
         "--debug"
-      ],
-      "justMyCode": true
+      ]
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,11 @@
 {
-    "python.pythonPath": "venv/bin/python",
-    "files.associations": {
-      "*.yaml": "home-assistant"
-    },
-    "ruff.enable": true,
-    "ruff.fixAll": true,
-    "ruff.lint.enable": true,
-    "ruff.format.args": [
-        "--line-length=120"
-    ]
-  }
+  "files.associations": {
+    "*.yaml": "home-assistant"
+  },
+  "ruff.enable": true,
+  "ruff.fixAll": true,
+  "ruff.lint.enable": true,
+  "ruff.format.args": [
+    "--line-length=120"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-  "files.associations": {
-    "*.yaml": "home-assistant"
-  },
-  "ruff.enable": true,
-  "ruff.fixAll": true,
-  "ruff.lint.enable": true,
-  "ruff.lineLength": 120
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,5 @@
   "ruff.enable": true,
   "ruff.fixAll": true,
   "ruff.lint.enable": true,
-  "ruff.format.args": [
-    "--line-length=120"
-  ]
+  "ruff.lineLength": 120
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,28 +2,22 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Run Home Assistant on port 9123",
+      "label": "Make config folder",
       "type": "shell",
-      "command": "container start",
+      "command": "mkdir -p ${workspaceFolder}/config",
       "problemMatcher": []
     },
     {
-      "label": "Run Home Assistant configuration against /config",
+      "label": "Run Home Assistant",
+      "dependsOn": "Make config folder",
       "type": "shell",
-      "command": "container check",
-      "problemMatcher": []
-    },
-    {
-      "label": "Upgrade Home Assistant to latest dev",
-      "type": "shell",
-      "command": "container install",
-      "problemMatcher": []
-    },
-    {
-      "label": "Install a specific version of Home Assistant",
-      "type": "shell",
-      "command": "container set-version",
-      "problemMatcher": []
+      "command": "~/.local/bin/hass --config ${workspaceFolder}/config --debug",
+      "problemMatcher": [],
+      "options": {
+        "env": {
+          "PYTHONPATH": "${env:PYTHONPATH}:${workspaceFolder}/custom_components"
+        }
+      }
     }
   ]
 }

--- a/Debug.md
+++ b/Debug.md
@@ -4,13 +4,12 @@ This project is configured to use devcontainers with Visual Studio code.
 
 *Prerequisites:*
 
-- Docker CE installed and working(On Windows WSL2 is absolutely encouraged)
-- Visual Studio code installed
-- Code extension for Dev Containers
+- Docker
+- Visual Studio code with "Dev Containers" extension.
 
 *Steps*
 
-1.  Launch root folder of repository in Vs Code:
+1.  Launch root folder of repository in VS Code:
 
 ```sh
 :~/git/ha-xcomfort-bridge$ code .
@@ -18,10 +17,5 @@ This project is configured to use devcontainers with Visual Studio code.
 ```
 
 2.  After VS Code is loaded, you should be prompted to re-open folder in container.  Do so.  This _might_ take a few minutes, but be patient.
-3.  Once this is done, everything should be set up.  Hit F5 to debug your code inside a running HomeAssistant instance
-4.  Open a browser to http://localhost:9123 (not 8123 !!) and complete the onboarding proccess and add your integration.
-
-*Troubleshooting*
-
-The dev container we are using, is based on `ghcr.io/ludeeus/devcontainer/integration` , which is a specialized container for developing extensions
-for HomeAssistant.  You can change running HomeAssistant version and other parameters by running command `container` from a shell inside visual studio.
+3.  Once this is done, everything should be set up. Hit F5 to debug your code inside a running HomeAssistant instance. This should work with breakpoints etc. Alternatively, use the "Run Home Assistant" task. This will start Hass on the defaul 8123 port.
+4.  Should be prompted to open in a browser, if not, then do Ctrl-Shift-p and select "Open port in browser" and then select "Home assistant (8123)".

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+homeassistant==2025.7.1
+pip>=21.3.1
+xcomfort==0.1.2


### PR DESCRIPTION
This project use an older variant for setting up a development environment for home assistant custom components. Which is a non-maintailed docker image. This commit updates this to use an approach that is very similar to what the template project https://github.com/ludeeus/integration_blueprint sets up.

Only the minimum changes are done, the linter is left alone as the setup seems to make sense. After starting the dev container (as before) in vscode, an home assistant instance with the custom component it started using either the vscode run/debug command or running a vscode task. If running in debug mode, then breakpoints etc should work.

Update devcontainer to dev the integration #1