### PR TITLE
Extend rocker name with comp name

### DIFF
--- a/custom_components/xcomfort_bridge/event.py
+++ b/custom_components/xcomfort_bridge/event.py
@@ -2,8 +2,8 @@
 
 import logging
 
-from xcomfort.devices import Light, Rocker, Shade
 from xcomfort.comp import Comp
+from xcomfort.devices import Light, Rocker, Shade
 
 from homeassistant.components.event import EventDeviceClass, EventEntity
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/xcomfort_bridge/event.py
+++ b/custom_components/xcomfort_bridge/event.py
@@ -3,6 +3,7 @@
 import logging
 
 from xcomfort.devices import Light, Rocker, Shade
+from xcomfort.comp import Comp
 
 from homeassistant.components.event import EventDeviceClass, EventEntity
 from homeassistant.config_entries import ConfigEntry
@@ -28,8 +29,9 @@ async def async_setup_entry(
         events = []
         for device in hub.devices:
             if isinstance(device, Rocker):
-                _LOGGER.debug("Adding %s", device)
-                event = XComfortEvent(hass, hub, device)
+                comp = device.bridge._comps.get(device.payload.get("compId", ""))
+                _LOGGER.debug("Adding %s %s", device, comp)
+                event = XComfortEvent(hass, hub, device, comp)
                 events.append(event)
 
         async_add_entities(events)
@@ -40,19 +42,20 @@ async def async_setup_entry(
 class XComfortEvent(EventEntity):
     """Entity class for xComfort event button."""
 
-    def __init__(self, hass: HomeAssistant, hub: XComfortHub, device: Rocker) -> None:
+    def __init__(self, hass: HomeAssistant, hub: XComfortHub, device: Rocker, comp: Comp) -> None:
         """Initialize the Event entity.
 
         Args:
             hass: HomeAssistant instance
             hub: XComfortHub instance
             device: Rocker device instance
+            comp: XComfort Comp instance
 
         """
         self._attr_device_class = EventDeviceClass.BUTTON
         self._attr_event_types = ["on", "off"]
         self._attr_has_entity_name = True
-        self._attr_name = device.name
+        self._attr_name = f"{comp.name} {device.name}"
         self._attr_unique_id = f"event_{DOMAIN}_{device.device_id}"
         self._device = device
 


### PR DESCRIPTION
When multiple rockers control one device, the rocker names will get _2, _3. This PR will add the actual name as defined in the Eaton app.