### PR TITLE
fix: add RcTouch device metadata

### DIFF
--- a/custom_components/xcomfort_bridge/device_info.py
+++ b/custom_components/xcomfort_bridge/device_info.py
@@ -1,0 +1,50 @@
+"""Helpers for Home Assistant device registry metadata."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import DOMAIN
+from .xcomfort.constants import ComponentTypes
+
+if TYPE_CHECKING:
+    from .xcomfort.comp import Comp
+    from .hub import XComfortHub
+    from .xcomfort.devices import RcTouch
+
+
+def _get_rctouch_component(hub: XComfortHub, device: RcTouch) -> Comp | None:
+    """Return the linked xComfort component for an RcTouch device."""
+    if device.comp_id is None:
+        return None
+    return hub.bridge.comps.get(device.comp_id)
+
+
+def _get_rctouch_model_name(comp: Comp | None) -> str:
+    """Return a human-readable RcTouch model name from discovery data."""
+    if comp is not None and comp.comp_type == ComponentTypes.RC_TOUCH:
+        return "RC Touch"
+    return "RcTouch"
+
+
+def get_rctouch_device_info(hub: XComfortHub, device: RcTouch) -> DeviceInfo:
+    """Return stable device metadata for an RcTouch device.
+
+    The identifier intentionally stays unchanged so existing Home Assistant
+    device registry entries can be updated in place instead of creating a new
+    device alongside the old unnamed one.
+    """
+    comp = _get_rctouch_component(hub, device)
+    comp_payload = comp.payload if comp is not None else {}
+
+    return DeviceInfo(
+        identifiers={(DOMAIN, f"climate_{DOMAIN}_{hub.identifier}-{device.device_id}")},
+        name=device.name or (comp.name if comp is not None else None) or f"RcTouch {device.device_id}",
+        manufacturer="Eaton",
+        model=_get_rctouch_model_name(comp),
+        sw_version=comp_payload.get("versionFW"),
+        hw_version=comp_payload.get("versionHW"),
+        via_device=(DOMAIN, hub.hub_id),
+    )

--- a/custom_components/xcomfort_bridge/event.py
+++ b/custom_components/xcomfort_bridge/event.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import BUTTON_EVENT, DOMAIN
+from .device_info import get_rctouch_device_info
 from .hub import XComfortHub
 from .xcomfort.comp import Comp
 from .xcomfort.constants import ComponentTypes
@@ -305,10 +306,7 @@ class XComfortRcTouchEvent(XComfortButtonEventBase):
         self._device = device
         self._init_button_event_state()
 
-        # Link to the RcTouch climate device
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"climate_{DOMAIN}_{hub.identifier}-{device.device_id}")},
-        )
+        self._attr_device_info = get_rctouch_device_info(hub, device)
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""

--- a/custom_components/xcomfort_bridge/sensor.py
+++ b/custom_components/xcomfort_bridge/sensor.py
@@ -35,6 +35,7 @@ from .const import (
     CONF_POWER_ENERGY_SECTION,
     DOMAIN,
 )
+from .device_info import get_rctouch_device_info
 from .hub import XComfortHub
 from .xcomfort.bridge import Room
 from .xcomfort.constants import ComponentTypes
@@ -479,11 +480,7 @@ class XComfortRcTouchTemperatureSensor(SensorEntity):
         self._state = None
         self._device.state.subscribe(self._state_change)
 
-        # Link to the climate device
-        device_id = f"climate_{DOMAIN}_{hub.identifier}-{device.device_id}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, device_id)},
-        )
+        self._attr_device_info = get_rctouch_device_info(hub, device)
 
     def _state_change(self, state):
         should_update = self._state is not None
@@ -524,11 +521,7 @@ class XComfortRcTouchHumiditySensor(SensorEntity):
         self._state = None
         self._device.state.subscribe(self._state_change)
 
-        # Link to the climate device
-        device_id = f"climate_{DOMAIN}_{hub.identifier}-{device.device_id}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, device_id)},
-        )
+        self._attr_device_info = get_rctouch_device_info(hub, device)
 
     def _state_change(self, state):
         should_update = self._state is not None


### PR DESCRIPTION
This PR proposes a small fix for RcTouch devices showing up with incomplete device information in Home Assistant.

Instead of creating a device entry with only an identifier, RcTouch entities now provide device metadata as well, so the device can be shown with:

name from the bridge configuration
model derived from the RcTouch component type
firmware version from bridge discovery data
hardware version when available
The change is intentionally minimal and limited to RcTouch only.
It does not change the current separation between RcTouch and xComfort Heating Actuator devices.

Potential benefits of this approach:

avoids Unnamed device entries for RcTouch devices
keeps existing device identifiers stable, so Home Assistant can update existing device registry entries in place
reuses discovery data already available from the bridge
keeps the metadata logic in one shared helper instead of duplicating it across entities
If this behavior is considered desirable, this should be a fairly small and low-risk improvement.

Closes #138 